### PR TITLE
If the TXT doesn't initially exist, we can accept that.

### DIFF
--- a/deploy/dreamhost-webhook/Chart.yaml
+++ b/deploy/dreamhost-webhook/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: "0.2.4"
+appVersion: "0.3.0"
 description: Dreamhost DNS-01 solver for Cert Manager
 name: dreamhost-webhook
 type: application
-version: 0.2.4
+version: 0.3.0

--- a/deploy/dreamhost-webhook/values.yaml
+++ b/deploy/dreamhost-webhook/values.yaml
@@ -14,7 +14,7 @@ certManager:
 
 image:
   repository: ghcr.io/nprzy/cert-manager-webhook-dreamhost
-  tag: 0.2.4
+  tag: 0.3.0
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/internal/dreamhost/dreamhost.go
+++ b/internal/dreamhost/dreamhost.go
@@ -73,9 +73,9 @@ func (c *DNSClient) CreateRecord(r DNSRecordValue, uniqueId string) error {
 //
 // Example GET request:
 // https://api.dreamhost.com/?key=1A2B3C4D5E6F7G8H&cmd=dns-remove_record&record=example.com&type=TXT&value=test123&format=json&unique_id=123456
-func (c *DNSClient) DeleteRecord(r DNSRecordValue, uniqueId string) error {
+func (c *DNSClient) DeleteRecord(r DNSRecordValue, uniqueId string) (*DreamhostResponse, error) {
 	resp, err := c.sendRequest(&r, "dns-remove_record", uniqueId)
-	return suppressUniqueIdUsedErr(resp, err)
+	return resp, suppressUniqueIdUsedErr(resp, err)
 }
 
 func (c *DNSClient) sendRequest(r *DNSRecordValue, cmd string, uniqueId string) (*DreamhostResponse, error) {

--- a/internal/dreamhost/dreamhost_test.go
+++ b/internal/dreamhost/dreamhost_test.go
@@ -75,8 +75,10 @@ func TestDeleteRecord(t *testing.T) {
 	c, err := NewClient(apiKey, nil, svr.URL)
 	assert.Nil(t, err, "expect NewClient err to be nil")
 
-	err = c.DeleteRecord(recordValue, "")
+	resp, err := c.DeleteRecord(recordValue, "")
 	assert.Nil(t, err, "expect DeleteRecord err to be nil")
+	assert.NotNil(t, resp, "expect DeleteRecord response not to be nil")
+	assert.Equal(t, "record_removed", resp.Data, "expect DeleteRecord to return record_removed in Data")
 }
 
 func TestCreateRecordWithUniqueId(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/nprzy/cert-manager-webhook-dreamhost/internal/dreamhost"
 	"github.com/pkg/errors"
@@ -116,8 +117,21 @@ func (c *dreamHostDnsProviderSolver) CleanUp(ch *v1alpha1.ChallengeRequest) erro
 	}
 
 	name := trimTrailingDot(ch.ResolvedFQDN)
-	err = client.DeleteRecord(dreamhost.DNSRecordValue{Name: name, RecordType: "TXT", Value: ch.Key}, "")
+	resp, err := client.DeleteRecord(dreamhost.DNSRecordValue{Name: name, RecordType: "TXT", Value: ch.Key}, "")
 	if err != nil {
+		// If the API indicates the record wasn't found, log a warning and continue.
+		// Check common DreamHost error strings in Data or Reason (case-insensitive).
+		var reason string
+		if resp != nil {
+			reason = strings.ToLower(strings.TrimSpace(resp.Data + " " + resp.Reason))
+		} else {
+			reason = ""
+		}
+		if reason != "" && (strings.Contains(reason, "does_not_exist") || strings.Contains(reason, "record_not_found") || strings.Contains(reason, "not_found") || strings.Contains(reason, "no_records") || strings.Contains(reason, "not exist") || strings.Contains(reason, "no such")) {
+			klog.Warningf("TXT record %v with value %v not found during cleanup: %v", ch.ResolvedFQDN, ch.Key, reason)
+			return nil
+		}
+
 		klog.Errorf("Dreamhost client failed to delete DNS record: %v", err)
 		return errors.Wrapf(err, "Dreamhost client failed to delete DNS record")
 	}


### PR DESCRIPTION
Currently, if the _acme-challenge txt record doesn't exist, it fails to delete (with a zone doesn't exist), and the cert never gets to be created.  This allows us to recover from that by printing a warning, and moving on.